### PR TITLE
Implement linear RGB to sRGB conversion for corrected output for monitor...

### DIFF
--- a/scenes/blackbody.scene
+++ b/scenes/blackbody.scene
@@ -27,7 +27,8 @@ Horizongrid=0
 Disktexture=blackbody
 Skytexture=texture
 Skydiskratio=0.05
-Fogmult=0.3
+Fogdo=1
+Fogmult=0.03
 
 Diskmultiplier=100
 Diskalphamultiplier=4000

--- a/scenes/default.scene
+++ b/scenes/default.scene
@@ -83,7 +83,7 @@ Skydiskratio=0.3
 #Toggle dust (0/1)
 Fogdo=1
 #Dust intensity multiplier
-Fogmult=0.2
+Fogmult=0.028991186547107816
 
 
 #Postprocessing options


### PR DESCRIPTION
I've implemented conversion between nonlinear sRGB (the colourspace used by practically any monitor and camera for displaying and storing images) and linear RGB. You can see a comparison of the results here https://www.dropbox.com/s/nohtojmx01vfmlj/tests.zip?dl=0 . The gist of it is that displaying an image rendered in linear RGB on a monitor results in a slightly washed-out image because of the monitor's gamma. Additionally, the textures are themselves most probably stored in sRGB colourspace and need to be converted to linear RGB before use. Also, you might want to significantly lower the fogmult parameter in all other scenes too - basically raise it to power 2.2. I'm assuming it was chosen for visual appeal not not based on physical measurements.

For an explanation on the colourspace itself, the wikipedia article https://en.wikipedia.org/wiki/SRGB is a good start. For a more long-winded explanation on how it affects image manipulation and what happens when you assume linear RGB in place of sRGB (or vice-versa), see http://www.4p8.com/eric.brasseur/gamma.html for example.

I apologise in advance if you are already familiar with this and simply left it out for simplicity's sake. The difference is not all that noticeable in this case anyway.
