### PR TITLE
Fix SKY_TEXTURE selection

### DIFF
--- a/tracer.py
+++ b/tracer.py
@@ -237,7 +237,7 @@ except KeyError:
     sys.exit(1)
 
 try:
-    SKY_TEXTURE_INT = dt_dict[SKY_TEXTURE]
+    SKY_TEXTURE_INT = st_dict[SKY_TEXTURE]
 except KeyError:
     logger.debug("Error: %s is not a valid sky rendering mode", SKY_TEXTURE)
     sys.exit(1)


### PR DESCRIPTION
`SKY_TEXTURE_INT` was selected from the same *dict* as `DT_TEXTURE_INT`, which seems to be the case of simple copy+paste error.  This leads to errors like:
```
Error: final is not a valid sky rendering mode
```